### PR TITLE
allow multiple roles in a single node

### DIFF
--- a/serf_master/__init__.py
+++ b/serf_master/__init__.py
@@ -6,7 +6,7 @@ import logging
 class SerfHandler(object):
     def __init__(self):
         self.name = os.environ['SERF_SELF_NAME']
-        self.role = os.environ.get('SERF_TAG_ROLE') or os.environ.get('SERF_SELF_ROLE')
+        self.roles = (os.environ.get('SERF_TAG_ROLE') or os.environ.get('SERF_SELF_ROLE')).split(":")
         self.logger = logging.getLogger(type(self).__name__)
         if os.environ['SERF_EVENT'] == 'user':
             self.event = os.environ['SERF_USER_EVENT']
@@ -29,19 +29,22 @@ class SerfHandlerProxy(SerfHandler):
         self.handlers[role] = handler
 
     def get_klass(self):
-        klass = False
-        if self.role in self.handlers:
-            klass = self.handlers[self.role]
-        elif 'default' in self.handlers:
-            klass = self.handlers['default']
+        klass = []
+        for role in self.roles:
+            if role in self.handlers:
+                klass.append(self.handlers[role])
+        if len(klass) == 0:
+            if 'default' in self.handlers:
+                klass = [self.handlers['default']]
         return klass
 
     def run(self):
         klass = self.get_klass()
-        if not klass:
+        if len(klass) == 0:
             self.log("no handler for role")
         else:
-            try:
-                getattr(klass, self.event)()
-            except AttributeError:
-                self.log("event not implemented by class")
+            for k in klass:
+                try:
+                    getattr(k, self.event)()
+                except AttributeError:
+                    self.log("event not implemented by class")

--- a/serf_master/tests/handler_test.py
+++ b/serf_master/tests/handler_test.py
@@ -25,7 +25,7 @@ class TestSerfHandler:
         assert self.handler.name == 'local'
 
     def test_role_set_from_env(self):
-        assert self.handler.role == 'web'
+        assert self.handler.roles == ['web']
 
     def test_event_set_from_env(self):
         assert self.handler.event == 'member_join'
@@ -48,7 +48,7 @@ class TestSerfHandlerTags:
     def setup(self):
         os.environ = {
             'SERF_SELF_NAME': 'null',
-            'SERF_TAG_ROLE': 'bob',
+            'SERF_TAG_ROLE': 'bob:tom',
             'SERF_EVENT': 'null',
         }
         self.handler = SerfHandlerProxy()
@@ -56,7 +56,7 @@ class TestSerfHandlerTags:
         assert len(self.handler.handlers) == 0
 
     def test_role_set_from_env(self):
-        assert self.handler.role == 'bob'
+        assert self.handler.roles == ['bob', 'tom']
 
 
 class TestSerfHandlerRoleOverloading:
@@ -73,7 +73,7 @@ class TestSerfHandlerRoleOverloading:
         assert len(self.handler.handlers) == 0
 
     def test_role_set_from_env(self):
-        assert self.handler.role == 'bob'
+        assert self.handler.roles == ['bob']
 
 
 class TestSerfHandlerNegativeCases:


### PR DESCRIPTION
Locate multiple services on the same node is a common practice. But the current implementation of the `serf-master` module does not support it. In order to allow this use-case, the 'role' tag could handle a list of roles.

```
serf agent -tag role="web:db" -event-handler /opt/your/script.py
```

So the event handler must extract that list of roles and then the proxy would be able to execute a collection of handlers instead of just one.

i'm not really comfortable with python, so don't hesitate to comment the proposed implementation :)
